### PR TITLE
add routes for listing all todos and get specific todo by id

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -7,7 +7,7 @@ const PORT = 3000;
 app.use(express.json());
 app.use("/api/todos", todosRoutes);
 
-app.use("/", (req, res) => res.status(200).send("Welcome to Todo API"));
+app.get("/", (req, res) => res.status(200).send("Welcome to Todo API"));
 
 app.listen(PORT, () => {
   console.log(`Server running on http://localhost:${PORT}`);

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,12 +1,13 @@
-import express from 'express';
-
+import express from "express";
+import todosRoutes from "./routes/todos.routes";
 
 const app = express();
 const PORT = 3000;
 
 app.use(express.json());
+app.use("/api/todos", todosRoutes);
 
-
+app.use("/", (req, res) => res.status(200).send("Welcome to Todo API"));
 
 app.listen(PORT, () => {
   console.log(`Server running on http://localhost:${PORT}`);

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,11 +1,11 @@
 import express from "express";
-import todosRoutes from "./routes/todos.routes";
+import apiRouter from "./routes/api.routes";
 
 const app = express();
 const PORT = 3000;
 
 app.use(express.json());
-app.use("/api/todos", todosRoutes);
+app.use("/api", apiRouter);
 
 app.get("/", (req, res) => res.status(200).send("Welcome to Todo API"));
 

--- a/src/routes/api.routes.ts
+++ b/src/routes/api.routes.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import todosRoutes from "./todos.routes";
+
+const apiRouter = Router();
+
+apiRouter.use("/todos", todosRoutes);
+
+export default apiRouter;

--- a/src/routes/todos.routes.ts
+++ b/src/routes/todos.routes.ts
@@ -1,0 +1,32 @@
+import { Router } from "express";
+import type { Request, Response } from "express";
+import type { Todo } from "../types/todo.types";
+
+const router = Router();
+
+// managing todos in memory
+let todos: Todo[] = [
+  {
+    id: 1,
+    text: "nour",
+    createdAt: new Date(),
+    completed: false,
+  },
+];
+
+router.get("/", (req: Request, res: Response) => {
+  res.status(200).json(todos);
+});
+
+router.get("/:id", (req: Request, res: Response) => {
+  let id = parseInt(req.params.id!);
+  let todo = todos.find((todo) => todo.id === id);
+  console.log(todo);
+  if (todo) {
+    res.status(200).json(todo);
+  } else {
+    res.status(404).send(`Todo with id: ${id} is not found.`);
+  }
+});
+
+export default router;

--- a/src/routes/todos.routes.ts
+++ b/src/routes/todos.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import type { Request, Response } from "express";
 import type { Todo } from "../types/todo.types";
+import { Status } from "../types/status.enum";
 
 const router = Router();
 
@@ -10,7 +11,7 @@ let todos: Todo[] = [
     id: 1,
     text: "nour",
     createdAt: new Date(),
-    completed: false,
+    status: Status.created,
   },
 ];
 
@@ -23,7 +24,6 @@ router.get("/", (req: Request, res: Response) => {
 router.get("/:id", (req: Request, res: Response) => {
   let id = parseInt(req.params.id!);
   let todo = todos.find((todo) => todo.id === id);
-  console.log(todo);
   if (todo) {
     res.status(200).json(todo);
   } else {

--- a/src/routes/todos.routes.ts
+++ b/src/routes/todos.routes.ts
@@ -6,14 +6,7 @@ import { Status } from "../types/status.enum";
 const router = Router();
 
 // managing todos in memory
-let todos: Todo[] = [
-  {
-    id: 1,
-    text: "nour",
-    createdAt: new Date(),
-    status: Status.created,
-  },
-];
+let todos: Todo[] = [];
 
 // GET: get all todos
 router.get("/", (req: Request, res: Response) => {

--- a/src/routes/todos.routes.ts
+++ b/src/routes/todos.routes.ts
@@ -14,10 +14,12 @@ let todos: Todo[] = [
   },
 ];
 
+// GET: get all todos
 router.get("/", (req: Request, res: Response) => {
   res.status(200).json(todos);
 });
 
+// GET: get specific to do by id
 router.get("/:id", (req: Request, res: Response) => {
   let id = parseInt(req.params.id!);
   let todo = todos.find((todo) => todo.id === id);

--- a/src/types/status.enum.ts
+++ b/src/types/status.enum.ts
@@ -1,0 +1,5 @@
+export enum Status {
+  created,
+  inprogress,
+  completed,
+}

--- a/src/types/todo.types.ts
+++ b/src/types/todo.types.ts
@@ -1,0 +1,6 @@
+export interface Todo {
+  id: number;
+  text: string;
+  createdAt: Date;
+  completed: boolean;
+}

--- a/src/types/todo.types.ts
+++ b/src/types/todo.types.ts
@@ -1,6 +1,8 @@
+import type { Status } from "./status.enum";
+
 export interface Todo {
   id: number;
   text: string;
   createdAt: Date;
-  completed: boolean;
+  status: Status;
 }


### PR DESCRIPTION
- Added a new route handler in 'src/routes/todos.routes.ts' for '/api/todos', including endpoints to list all todos and fetch a todo by ID, with todos managed in memory.
- Registered the new todosRoutes in the main Express app.
- Added a default route that responds with a welcome message for the root path.
- Created a new Todo interface in to define the todo objects used in the API.
- All endpoints have been tested through Postman