### PR TITLE
feat: add POST /api/todos route to create a new todo

### DIFF
--- a/src/routes/todos.routes.ts
+++ b/src/routes/todos.routes.ts
@@ -5,14 +5,8 @@ import type { Todo } from "../types/todo.types";
 const router = Router();
 
 // managing todos in memory
-let todos: Todo[] = [
-  {
-    id: 1,
-    text: "nour",
-    createdAt: new Date(),
-    completed: false,
-  },
-];
+let todos: Todo[] = [];
+let counter = 1;
 
 // GET: get all todos
 router.get("/", (req: Request, res: Response) => {
@@ -29,6 +23,23 @@ router.get("/:id", (req: Request, res: Response) => {
   } else {
     res.status(404).send(`Todo with id: ${id} is not found.`);
   }
+});
+
+// POST: create a new todo
+router.post("/", (req: Request, res: Response) => {
+  const { text } = req.body;
+  if (!text) {
+    return res.status(400).send("Bad request");
+  }
+
+  const newTodo: Todo = {
+    id: counter++,
+    text: text,
+    createdAt: new Date(),
+    completed: false,
+  };
+  todos.push(newTodo);
+  res.status(201).json(newTodo);
 });
 
 export default router;


### PR DESCRIPTION
Removed the default hardcoded todo from the initial `todos` array, starting the list empty instead.
Introduced a `counter` variable to generate unique IDs for new todos.
Added a POST `/` endpoint to create a new todo, including validation for the `text` field and automatic assignment of ID and timestamp.